### PR TITLE
Alternate shutdown logic

### DIFF
--- a/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
+++ b/unix-domain-socket/src/main/scala/akka/stream/alpakka/unixdomainsocket/scaladsl/UnixDomainSocket.scala
@@ -297,7 +297,7 @@ object UnixDomainSocket extends ExtensionId[UnixDomainSocket] with ExtensionIdPr
           sent.future.map(_ => bytes)
         }
         .watchTermination() {
-          case (m, done) =>
+          case (_, done) =>
             done.onComplete { _ =>
               sendReceiveContext.send = if (halfClose) {
                 ShutdownRequested


### PR DESCRIPTION
ShutdownRequested is now only performed if it makes sense to - as before, but I think this is a little clearer...

Also, if a shutdown occurs, then we unsubscribe from interest in writing so that we don't keep going round and round in the nio loop.

Finally, some re-ordering of the send events to reflect their typically sequence.
